### PR TITLE
Set the accessory displayName attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function MiFlowerCarePlugin(log, config) {
     var that = this;
     this.log = log;
     this.name = config.name;
+    this.displayName = this.name;
     this.deviceId = config.deviceId;
     this.interval = Math.min(Math.max(config.interval, 1), 600);
 


### PR DESCRIPTION
Hi Tobias,

Thanks for this Homebridge plugin for the Xiaomi Mi Flora, it works really well!

This tiny patch simply sets the accessory `displayName` attribute, as it is expected by fakegato-history as part of the file name when using the filesystem storage. Without this change the file is called something like `raspberrypi_undefined_persist.json` and could conflict with other plugins.

Another way to fix it would be to rename the `name` attribute to `displayName`, but this touches more lines of code and I didn't know whether you wanted this so I simply added another attribute. I'm happy to change the PR if you prefer.